### PR TITLE
Run ThinBkrHandler thread loop as daemon.

### DIFF
--- a/teres/bkr_handlers.py
+++ b/teres/bkr_handlers.py
@@ -127,6 +127,7 @@ class ThinBkrHandler(teres.Handler):
         self.finished = False
         self.flush_delay = flush_delay
         self.async_thread = threading.Thread(target=self._thread_loop)
+        self.async_thread.daemon = True
         self.async_thread.start()
 
     def _get_recipe(self):


### PR DESCRIPTION
This is required e.g. in cases where main thread crashes or doesn't call
close.