### PR TITLE
Cleanup is fork-aware

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,14 @@ provides two handler classes :py:class:`teres.handlers.LoggingHandler` and
 :py:class:`teres.bkr_handlers.ThinBkrHandler` for reporting to *stdout* and to
 beaker_ lab controller.
 
+Constraints
+-----------
+
+If using `teres` module in code together with `os.fork`, the `teres` module
+must be used in the same process where it's imported first (main process).
+This is caused by `cleanup` which is called at the end of python process and
+ensures, that all logs are correctly reported. The `cleanup` however ends
+tests only in the main process, enabling usage of `os.fork`.
 
 The API
 -------

--- a/teres/__init__.py
+++ b/teres/__init__.py
@@ -22,9 +22,11 @@ handlers. In it's core it's highly inspired byt implementation fo python logging
 module.
 """
 
+import os
+import atexit
+
 # These are default test results and their values. This should be reset to 0
 # after particular test is finished.
-import atexit
 
 FILE = 99
 ERROR = 50
@@ -34,6 +36,8 @@ INFO = 20
 DEBUG = 10
 NONE = 0
 
+# used in cleanup function
+_PID = os.getpid()
 
 def result_to_name(result):
     """
@@ -57,6 +61,10 @@ def cleanup():
     """
     Cleanup method.
     """
+    # when somebody uses fork() and the process ends, don't do anything,
+    # since this is handled by parent process
+    if _PID != os.getpid():
+        return
     Reporter.get_reporter().test_end()
 
 


### PR DESCRIPTION
cleanup function was called even in forked environment, e.g. at sys.exit
and may have caused problems when running test_end in child environment.