### PR TITLE
Don't do anything with unknown log file types.

### DIFF
--- a/teres/bkr_handlers.py
+++ b/teres/bkr_handlers.py
@@ -330,6 +330,7 @@ class ThinBkrHandler(teres.Handler):
 
         else:
             logger.error("Unable to handle this file type.")
+            return
 
         logger.debug("ThinBkrHandler: calling _emit_file: %s as %s",
                      record.logfile, record.logname)

--- a/teres/handlers.py
+++ b/teres/handlers.py
@@ -139,6 +139,7 @@ class LoggingHandler(teres.Handler):
 
         else:
             self.logger.error("Unable to handle this file type.")
+            return
 
         self.logger.debug("LoggingHandler: calling _emit_file: %s as %s",
                           record.logfile, record.logname)


### PR DESCRIPTION
There's msg variable used later even though it's not assigned.
There are even more things that could go wrong and produce traceback.

This also may be issue of teres not being able to send files to beasker
after some event. The sending thread could be dead due to traceback.