### PR TITLE
Deal with negative time shifts.

### DIFF
--- a/teres/bkr_handlers.py
+++ b/teres/bkr_handlers.py
@@ -495,7 +495,7 @@ class ThinBkrHandler(teres.Handler):
             except QueueEmpty:
                 pass
 
-            if not synced and (time.time() - last_update > self.flush_delay):
+            if not synced and not (0 < time.time() - last_update < self.flush_delay):
                 self._thread_flush()
                 synced = True
                 last_update = time.time()


### PR DESCRIPTION
When system time moves to past, the time.time() - last_update
is negative. In that case, we have no idea how much time has really
passed from last update, so let's flush the log and reset last_update.