### PR TITLE
Drop support for Python 2

### DIFF
--- a/teres/__init__.py
+++ b/teres/__init__.py
@@ -29,7 +29,6 @@ import atexit
 import traceback
 import threading
 import functools
-import six
 import time
 import io
 
@@ -131,7 +130,7 @@ def cleanup():
 
     if tb is not None:
         tb_msg = repr(vl) + '\n' + "".join(traceback.format_tb(tb))
-        fo = io.StringIO(six.u(tb_msg))
+        fo = io.StringIO(tb_msg)
         reporter.send_file(fo, "traceback.log")
 
         dump = dump_tb(tb)
@@ -148,7 +147,7 @@ def make_text(smth):
     """
     Helper function to coerce UTF-8 bytes into str
     """
-    if isinstance(smth, six.binary_type):
+    if isinstance(smth, bytes):
         return smth.decode('utf8')
     return smth
 
@@ -157,7 +156,7 @@ def make_bytes(smth):
     """
     Helper function to coerce str into UTF-8 bytes
     """
-    if isinstance(smth, six.text_type):
+    if isinstance(smth, str):
         return smth.encode('utf8')
     return smth
 

--- a/teres/__init__.py
+++ b/teres/__init__.py
@@ -146,7 +146,7 @@ def cleanup():
 
 def make_text(smth):
     """
-    Helper function for python2&3 support.
+    Helper function to coerce UTF-8 bytes into str
     """
     if isinstance(smth, six.binary_type):
         return smth.decode('utf8')
@@ -155,7 +155,7 @@ def make_text(smth):
 
 def make_bytes(smth):
     """
-    Helper function for python2&3 support.
+    Helper function to coerce str into UTF-8 bytes
     """
     if isinstance(smth, six.text_type):
         return smth.encode('utf8')

--- a/teres/__init__.py
+++ b/teres/__init__.py
@@ -33,10 +33,7 @@ import six
 import time
 import io
 
-try:
-    FILE_TYPES = (file,)
-except NameError:
-    FILE_TYPES = (io.IOBase,)
+FILE_TYPES = (io.IOBase,)
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/teres/bkr_handlers.py
+++ b/teres/bkr_handlers.py
@@ -500,15 +500,15 @@ class ThinBkrHandler(teres.Handler):
             try:
                 record_type, record = self.record_queue.get(timeout=0.1)
 
-                logger.debug("THREAD(%s) start _thread_emit_*", threading.currentThread().ident)
+                logger.debug("THREAD(%s) start _thread_emit_*", threading.current_thread().ident)
                 if record_type == _LOG:
-                    logger.debug("THREAD(%s) _thread_emit_log", threading.currentThread().ident)
+                    logger.debug("THREAD(%s) _thread_emit_log", threading.current_thread().ident)
                     self._thread_emit_log(record)
                     synced = False
                 elif record_type == _FILE:
-                    logger.debug("THREAD(%s) _thread_emit_file", threading.currentThread().ident)
+                    logger.debug("THREAD(%s) _thread_emit_file", threading.current_thread().ident)
                     self._thread_emit_file(record)
-                logger.debug("THREAD(%s) end _thread_emit_*", threading.currentThread().ident)
+                logger.debug("THREAD(%s) end _thread_emit_*", threading.current_thread().ident)
 
             except QueueEmpty:
                 pass

--- a/teres/bkr_handlers.py
+++ b/teres/bkr_handlers.py
@@ -195,19 +195,6 @@ def _path_to_name(path):
     return os.path.basename(path).replace(' ', '_')
 
 
-def _get_location_header(smth):
-    """
-    Python 2 and 3 helper function.
-    """
-    try:
-        # python3
-        return smth.getheader("Location") + "/"
-    except AttributeError:
-        # python2
-        return smth.info().getheader("Location") + "/"
-
-    return smth
-
 class ThinBkrHandlerError(teres.HandlerError):
     """
     Exception for beaker handler module.
@@ -379,7 +366,7 @@ class ThinBkrHandler(teres.Handler):
 
             req = http_post(url, data)
 
-            self.last_result_url = _get_location_header(req)
+            self.last_result_url = req.getheader("Location") + "/"
 
             if record.flags.get(DEFAULT_LOG_DEST, False):
                 self.default_log_dest = self.last_result_url

--- a/teres/bkr_handlers.py
+++ b/teres/bkr_handlers.py
@@ -33,17 +33,10 @@ import datetime
 import functools
 import six
 import socket
-
-try:
-    from urllib.parse import urlencode
-    from urllib.request import urlopen, build_opener, Request, HTTPHandler
-    from queue import Queue
-    from queue import Empty as QueueEmpty
-except ImportError:
-    from urllib import urlencode
-    from urllib2 import urlopen, build_opener, Request, HTTPHandler
-    from Queue import Queue
-    from Queue import Empty as QueueEmpty
+from urllib.parse import urlencode
+from urllib.request import urlopen, build_opener, Request, HTTPHandler
+from queue import Queue
+from queue import Empty as QueueEmpty
 
 # Flags defintion
 class Flag(object):

--- a/teres/bkr_handlers.py
+++ b/teres/bkr_handlers.py
@@ -31,7 +31,6 @@ import time
 import io
 import datetime
 import functools
-import six
 import socket
 from urllib.parse import urlencode
 from urllib.request import urlopen, build_opener, Request, HTTPHandler

--- a/teres/handlers.py
+++ b/teres/handlers.py
@@ -27,10 +27,7 @@ import shutil
 import teres
 import io
 
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 
 
 def _result_to_level(result):

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 
 # Run the test suite.
-python2 -m unittest discover -v &&
 python3 -m unittest discover -v

--- a/tests/test_bkr_handlers.py
+++ b/tests/test_bkr_handlers.py
@@ -10,7 +10,6 @@ import requests
 import teres
 import teres.bkr_handlers
 import tempfile
-import six
 
 ENV = not bool(os.environ.get("BEAKER_RECIPE_ID") and os.environ.get("BEAKER_LAB_CONTROLLER_URL"))
 
@@ -97,7 +96,7 @@ class BkrTest(BkrEnv):
         self.reporter.send_file('/tmp/foo bar')
 
         tmp = tempfile.TemporaryFile()
-        tmp.write(six.b("I'm a temporary file."))
+        tmp.write("I'm a temporary file.".encode('latin-1'))
         self.reporter.send_file(tmp)
         self.reporter.send_file(tmp, logname="tmp_file")
 

--- a/tests/test_bkr_handlers.py
+++ b/tests/test_bkr_handlers.py
@@ -96,7 +96,7 @@ class BkrTest(BkrEnv):
         self.reporter.send_file('/tmp/foo bar')
 
         tmp = tempfile.TemporaryFile()
-        tmp.write("I'm a temporary file.".encode('latin-1'))
+        tmp.write("I'm a temporary file.".encode())
         self.reporter.send_file(tmp)
         self.reporter.send_file(tmp, logname="tmp_file")
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -8,7 +8,6 @@ import os.path
 import shutil
 import io
 import tempfile
-import six
 
 
 class LoggingHandlerSetUp(unittest.TestCase):
@@ -77,7 +76,7 @@ class LoggingHandlerTest(LoggingHandlerSetUp):
         text = "This is my temporary file."
 
         src_file = tempfile.TemporaryFile()
-        src_file.write(six.b(text))
+        src_file.write(text.encode('latin-1'))
         self.reporter.send_file(src_file, logname=test)
         src_file.close()
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -76,7 +76,7 @@ class LoggingHandlerTest(LoggingHandlerSetUp):
         text = "This is my temporary file."
 
         src_file = tempfile.TemporaryFile()
-        src_file.write(text.encode('latin-1'))
+        src_file.write(text.encode())
         self.reporter.send_file(src_file, logname=test)
         src_file.close()
 


### PR DESCRIPTION
As we've agreed on internal channel; Python 2 is not needed anymore and it's making things finnicky for other changes that we need, such as #30.